### PR TITLE
Feat: "추가 회원가입, 아이디 중복 검사, 닉네임 중복 검사 API 구현"

### DIFF
--- a/src/main/java/com/sns/mcc/controller/UserController.java
+++ b/src/main/java/com/sns/mcc/controller/UserController.java
@@ -2,6 +2,7 @@ package com.sns.mcc.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.sns.mcc.dto.request.*;
+import com.sns.mcc.dto.response.UserDuplicateResponse;
 import com.sns.mcc.service.KakaoUserService;
 import com.sns.mcc.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -17,20 +18,20 @@ public class UserController {
 
     //회원가입
     @PostMapping("/user/signup")
-    public ResponseEntity<?> userSignup(@RequestBody UserSignUpRequest userSignUpRequest) {
+    public ResponseEntity<Object> userSignup(@RequestBody UserSignUpRequest userSignUpRequest) {
         return userService.userSignup(userSignUpRequest);
     }
 
     //아이디 중복 확인
     @PostMapping("/user/id")
-    public ResponseEntity<?> duplicateCheckUsername(@RequestBody DuplicateCheckUsernameRequest duplicateCheckUsernameRequest) {
-        return userService.duplicateCheckUsername(duplicateCheckUsernameRequest);
+    public UserDuplicateResponse duplicateCheckUsername(@RequestBody DuplicateCheckUsernameRequest duplicateCheckUsernameRequest) {
+        return userService.duplicateCheckUsername(duplicateCheckUsernameRequest.getUsername());
     }
 
     //닉네임 중복 확인
     @PostMapping("/user/nickname")
-    public ResponseEntity<?> duplicateCheckNickname(@RequestBody DuplicateCheckNicknameRequest duplicateCheckNicknameRequest) {
-        return userService.duplicateCheckNickname(duplicateCheckNicknameRequest);
+    public UserDuplicateResponse duplicateCheckNickname(@RequestBody DuplicateCheckNicknameRequest duplicateCheckNicknameRequest) {
+        return userService.duplicateCheckNickname(duplicateCheckNicknameRequest.getNickname());
     }
 
     //로그인

--- a/src/main/java/com/sns/mcc/dto/response/UserDuplicateResponse.java
+++ b/src/main/java/com/sns/mcc/dto/response/UserDuplicateResponse.java
@@ -1,0 +1,11 @@
+package com.sns.mcc.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserDuplicateResponse {
+    private boolean exist;
+    private String message;
+}

--- a/src/main/java/com/sns/mcc/entity/User.java
+++ b/src/main/java/com/sns/mcc/entity/User.java
@@ -3,6 +3,7 @@ package com.sns.mcc.entity;
 import com.sns.mcc.dto.request.UserSignUpRequest;
 import com.sns.mcc.enums.UserRole;
 import com.sns.mcc.utill.TimeStamped;
+import com.sns.mcc.validator.UserValidator;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,6 +32,11 @@ public class User extends TimeStamped {
     private UserRole role;
 
     public User(UserSignUpRequest param, UserRole role) {
+
+        UserValidator.validateUsername(param.getUsername());
+        UserValidator.validateNickname(param.getNickname());
+        UserValidator.validatePassword(param.getPassword());
+
         this.username = param.getUsername();
         this.nickname = param.getNickname();
         this.password = param.getPassword();

--- a/src/main/java/com/sns/mcc/repository/UserRepository.java
+++ b/src/main/java/com/sns/mcc/repository/UserRepository.java
@@ -3,5 +3,9 @@ package com.sns.mcc.repository;
 import com.sns.mcc.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/sns/mcc/service/UserService.java
+++ b/src/main/java/com/sns/mcc/service/UserService.java
@@ -1,36 +1,78 @@
 package com.sns.mcc.service;
 
 import com.sns.mcc.dto.request.*;
+import com.sns.mcc.dto.response.UserDuplicateResponse;
+import com.sns.mcc.entity.User;
+import com.sns.mcc.enums.UserRole;
 import com.sns.mcc.repository.UserRepository;
+import com.sns.mcc.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
 @Transactional(readOnly = true)
 public class UserService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     //회원가입
     @Transactional
-    public ResponseEntity<?> userSignup(UserSignUpRequest userSignUpRequest) {
+    public ResponseEntity<Object> userSignup(UserSignUpRequest userSignUpRequest) {
+        boolean usernameCheck = this.duplicateCheckUsername(userSignUpRequest.getUsername()).isExist();
+        boolean nicknameCheck = this.duplicateCheckNickname(userSignUpRequest.getNickname()).isExist();
+        if (usernameCheck) {
+            return new ResponseEntity<>("사용 불가능한 아이디 입니다.", HttpStatus.BAD_REQUEST);
+        } else if (nicknameCheck) {
+            return new ResponseEntity<>("사용 불가능한 닉네임 입니다.", HttpStatus.BAD_REQUEST);
+        } else if (!userSignUpRequest.getPassword().equals(userSignUpRequest.getPasswordChk())) {
+            return new ResponseEntity<>("비밀번호와 재확인 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+        } else {
+            UserRole role = UserRole.USER;
 
+            User beforeSaveUser = new User(userSignUpRequest, role);
+            beforeSaveUser.encryptPassword(passwordEncoder);
+            userRepository.save(beforeSaveUser);
+        }
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
     //아이디 중복 확인
-    public ResponseEntity<?> duplicateCheckUsername(DuplicateCheckUsernameRequest duplicateCheckUsernameRequest) {
+    public UserDuplicateResponse duplicateCheckUsername(String username) {
+        Optional<User> usernameCheck = userRepository.findByUsername(username);
+        UserDuplicateResponse userDuplicateResponse = new UserDuplicateResponse();
 
-        return new ResponseEntity<>(HttpStatus.OK);
+        if (usernameCheck.isPresent()) {
+            userDuplicateResponse.setExist(true);
+            userDuplicateResponse.setMessage("중복된 아이디 입니다.");
+        } else {
+            UserValidator.validateUsername(username);
+            userDuplicateResponse.setExist(false);
+            userDuplicateResponse.setMessage("사용 가능한 아이디 입니다.");
+        }
+        return userDuplicateResponse;
     }
 
     //닉네임 중복 확인
-    public ResponseEntity<?> duplicateCheckNickname(DuplicateCheckNicknameRequest duplicateCheckNicknameRequest) {
+    public UserDuplicateResponse duplicateCheckNickname(String nickname) {
+        Optional<User> nicknameCheck = userRepository.findByNickname(nickname);
+        UserDuplicateResponse userDuplicateResponse = new UserDuplicateResponse();
 
-        return new ResponseEntity<>(HttpStatus.OK);
+        if (nicknameCheck.isPresent()) {
+            userDuplicateResponse.setExist(true);
+            userDuplicateResponse.setMessage("중복된 닉네임 입니다.");
+        } else {
+            UserValidator.validateNickname(nickname);
+            userDuplicateResponse.setExist(false);
+            userDuplicateResponse.setMessage("사용 가능한 닉네임 입니다.");
+        }
+        return userDuplicateResponse;
     }
 
     //로그인

--- a/src/main/java/com/sns/mcc/validator/UserValidator.java
+++ b/src/main/java/com/sns/mcc/validator/UserValidator.java
@@ -1,4 +1,57 @@
 package com.sns.mcc.validator;
 
+import com.sns.mcc.enums.ErrorCode;
+import com.sns.mcc.exception.CustomSignUpException;
+
 public class UserValidator {
+    public static void validateUsername(String username){
+        try {
+            //ID 검사
+            if(username == null){
+                throw new IllegalArgumentException("아이디를 입력해 주세요");
+            }
+            if (username.trim().equals("")) {
+                throw new IllegalArgumentException("아이디를 입력해 주세요");
+            }
+//            if (!username.matches("^[가-힣a-zA-Z]+$")) {
+//                throw new IllegalArgumentException("아이디 형식을 확인해 주세요");
+//            }
+        } catch (Exception e) {
+            throw new CustomSignUpException(ErrorCode.SIGN_UP_DATA_VALID);
+        }
+    }
+
+    public static void validateNickname(String nickname){
+        try {
+            //닉네임 검사
+            if(nickname == null){
+                throw new IllegalArgumentException("닉네임을 입력해 주세요");
+            }
+            if (nickname.trim().equals("")) {
+                throw new IllegalArgumentException("닉네임을 입력해 주세요");
+            }
+//            if (!nickname.matches("^[가-힣a-zA-Z]+$")) {
+//                throw new IllegalArgumentException("닉네임 형식을 확인해 주세요");
+//            }
+        } catch (Exception e) {
+            throw new CustomSignUpException(ErrorCode.SIGN_UP_DATA_VALID);
+        }
+    }
+
+    public static void validatePassword(String password){
+        try {
+            //비밀번호 검사
+            if(password == null){
+                throw new IllegalArgumentException("비밀번호를 입력해 주세요");
+            }
+            if (password.trim().equals("")) {
+                throw new IllegalArgumentException("비밀번호를 입력해 주세요");
+            }
+//            if (!password.matches("^[가-힣a-zA-Z]+$")) {
+//                throw new IllegalArgumentException("비밀번호 형식을 확인해 주세요");
+//            }
+        } catch (Exception e) {
+            throw new CustomSignUpException(ErrorCode.SIGN_UP_DATA_VALID);
+        }
+    }
 }


### PR DESCRIPTION
- 프론트엔드에서 회원가입시 아이디 중복 검사 API와 닉네임 중복 검사 API를 반드시 통과 해야 하지만,
- 만약의 경우를 대비하여 서버에서도 회원가입시 중복 검사를 실시하고
- 각종 형식 검사또한 각각 API마다 실행하도록 구현